### PR TITLE
update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can use custom emojis on Roblox! Alternatives for Twemoji (FOSS).
 * <img src="https://github.com/OrigamingWasTaken/appleblox/raw/main/.github/assets/logo.png" alt="AppleBlox" width="17" height="17"/> [AppleBlox](http://github.com/OrigamingWasTaken/appleblox) <sup>`FOSS`</sup>
 #### 🐧Linux:
 * <img src="https://github.com/vinegarhq/sober/raw/master/sober.svg" alt="Sober" width="17" height="17"/> [Sober](http://github.com/vinegarhq/sober)
-* <img src="https://raw.githubusercontent.com/xTrayambak/lucem/refs/heads/master/src/assets/lucem.png" alt="Lucem" width="17" height="17"/> [Lucem](https://github.com/xTrayambak/lucem) <sup>`FOSS`</sup> <sup>`FORK`</sup>
+* <img src="https://raw.githubusercontent.com/xTrayambak/lucem/refs/heads/master/src/assets/lucem.png" alt="Lucem" width="17" height="17"/> [Lucem](https://github.com/xTrayambak/lucem) <sup>`🪦`</sup> <sup>`FOSS`</sup> <sup>`FORK`</sup>
 * <img src="https://github.com/vinegarhq/vinegar/blob/master/data/icons/vinegar.svg" alt="Vinegar" width="17" height="17"/> [Vinegar](http://github.com/vinegarhq/vinegar) <sup>`FOSS`</sup>
 * <img src="https://gitlab.com/uploads/-/system/project/avatar/11688812/Grapejuice.png" alt="Grapejuice" width="17" height="17"/> [Grapejuice](http://gitlab.com/brinkervii/grapejuice) <sup>`FOSS`</sup>
 * <img src="https://github.com/Bugadinho/Cork/raw/master/resources/cork.svg" alt="Cork" width="17" height="17"/> [Cork](http://github.com/CorkHQ/Cork) <sup>`FOSS`</sup>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can use custom emojis on Roblox! Alternatives for Twemoji (FOSS).
 #### 🍎macOS:
 * <img src="https://github.com/OrigamingWasTaken/appleblox/raw/main/.github/assets/logo.png" alt="AppleBlox" width="17" height="17"/> [AppleBlox](http://github.com/OrigamingWasTaken/appleblox) <sup>`FOSS`</sup>
 #### 🐧Linux:
-* <img src="https://github.com/vinegarhq/sober/raw/master/sober.svg" alt="Sober" width="17" height="17"/> [Sober](http://github.com/vinegarhq/sober) <sup>`FOSS`</sup>
+* <img src="https://github.com/vinegarhq/sober/raw/master/sober.svg" alt="Sober" width="17" height="17"/> [Sober](http://github.com/vinegarhq/sober)
 * <img src="https://raw.githubusercontent.com/xTrayambak/lucem/refs/heads/master/src/assets/lucem.png" alt="Lucem" width="17" height="17"/> [Lucem](https://github.com/xTrayambak/lucem) <sup>`FOSS`</sup> <sup>`FORK`</sup>
 * <img src="https://github.com/vinegarhq/vinegar/blob/master/data/icons/vinegar.svg" alt="Vinegar" width="17" height="17"/> [Vinegar](http://github.com/vinegarhq/vinegar) <sup>`FOSS`</sup>
 * <img src="https://gitlab.com/uploads/-/system/project/avatar/11688812/Grapejuice.png" alt="Grapejuice" width="17" height="17"/> [Grapejuice](http://gitlab.com/brinkervii/grapejuice) <sup>`FOSS`</sup>


### PR DESCRIPTION
- removed foss tag from sober because it is a misconception that it is open source. it is not mainly in order to prevent malicious activity from occurring, thus making roblox on linux last longer.
- mark lucem as discontinued because it has been archived since may 8th.